### PR TITLE
Ml deployment

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -159,5 +159,6 @@ def analyze_product_review(
 
 
 if __name__ == "__main__":
-   import uvicorn
-   uvicorn.run(app, host="0.0.0.0", port=8000)
+    import uvicorn
+    port = int(os.environ.get("PORT", 8000))  # fallback for local testing
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/api/app.py
+++ b/api/app.py
@@ -32,16 +32,16 @@ key: str = os.environ.get("SUPABASE_KEY")
 supabase: Client = create_client(url, key)
 
 
-tokenizer = AutoTokenizer.from_pretrained("cardiffnlp/twitter-roberta-base-sentiment")
-model = AutoModelForSequenceClassification.from_pretrained("cardiffnlp/twitter-roberta-base-sentiment")
+tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")
+model = AutoModelForSequenceClassification.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")
+#changed these for render storage situations
 sentiment_pipeline = pipeline("sentiment-analysis", model=model, tokenizer=tokenizer)
 
 
 #LABEL_0 -> negative, LABEL_1 -> neutral, LABEL_2 -> positive
 label_mapping = {
-   "LABEL_0": "negative",
-   "LABEL_1": "neutral",
-   "LABEL_2": "positive"
+    "LABEL_0": "negative",
+    "LABEL_1": "positive"
 }
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,4 @@ transformers>=4.51.0
 torch
 supabase
 python-dotenv
+gunicorn

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ torch
 supabase
 python-dotenv
 gunicorn
+uvicorn


### PR DESCRIPTION
This PR finalizes deployment of our sentiment analysis FastAPI service to Render.  
The live API is now hosted at:  https://fitcheck-sentiment-analysis.onrender.com/ 

if this link does not work (model can spin out as it is the free tier) I can start it back up again as well


 Changes Made

- **Render Deployment**
  - Configured `buildCommand` and `startCommand` to align with the project structure (`api/app.py`).
  - Defined essential environment variables: `SUPABASE_URL`, `SUPABASE_KEY`.

- **Model Optimization**
  - Replaced large `cardiffnlp/twitter-roberta-base-sentiment` model with a smaller, more efficient alternative:  
    `distilbert-base-uncased-finetuned-sst-2-english`.
  - Updated sentiment label mapping (binary classification: `positive`/`negative`) to match new model output.
  - Significantly reduced memory usage to stay under Render's 512MiB free tier limit.

- **Dynamic Port Binding**
  - Adjusted the `uvicorn` command to use the environment-provided `$PORT`, as required by Render for port detection.


This image doesnt show any real analysis as there is being no data sent to the model, it is just the model up and running!
![image](https://github.com/user-attachments/assets/31c9dfd3-a5bc-492d-8b0d-64089ad10921)
![image](https://github.com/user-attachments/assets/1ef17423-f3b5-4a4b-9145-d0364183d769)
